### PR TITLE
force https in external urls

### DIFF
--- a/util.py
+++ b/util.py
@@ -49,4 +49,4 @@ def pid_id(pid):
 
 def get_id_url(id, filename):
     pid = id_pid(id, filename)
-    return url_for('.get', id=pid, _external=True)
+    return url_for('.get', id=pid, _external=True, _scheme='https')


### PR DESCRIPTION
before:

```
% curl -F c=@- localhost:10002 < foo.py 
http://localhost:10002/AAAn
uuid: fb54c683-bb5d-4adb-9073-61d13d26c326
```

after:

```
% curl -F c=@- localhost:10002 < foo.py 
https://localhost:10002/AAAn
uuid: fb54c683-bb5d-4adb-9073-61d13d26c326
```

This seems like a good hack for now; but I should probably read moar Werkzeug and we should instead honor `X-Forwarded-Proto`.
