### PR TITLE
request.blueprint could be null if no routes match

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -33,7 +33,7 @@ def invalidate(url):
 
 def add_cache_header(response):
     if request.method == 'GET' and not response.cache_control.public:
-        prefix = request.blueprint
+        prefix = request.blueprint if request.blueprint else current_app.name
         etag = "{}-{}".format(prefix, sha1(response.data).hexdigest())
         response.set_etag(etag)
         response.cache_control.public = True


### PR DESCRIPTION
polyzen unwittingly pointed this out--almost but not quite fixed in #44 .
