### PR TITLE
replace b85 with custom b36

### DIFF
--- a/url/views.py
+++ b/url/views.py
@@ -1,15 +1,18 @@
 from flask import Blueprint
 
 from db import cursor
-from util import redirect, request_content, id_url, b85_id, id_b85
+from util import redirect, request_content, id_url, int_b36
 from url import model
 
 url = Blueprint('url', __name__)
 
-@url.route('/<string(length=3):b85>')
+@url.route('/<string(length=3):b36>')
 @cursor
-def get(b85):
-    id = b85_id(b85)
+def get(b36):
+    try:
+        id = int(b36, 36)
+    except ValueError:
+        return 'Invalid id.\n', 400
 
     content = model.get_content(id)
     if not content:
@@ -32,5 +35,5 @@ def post():
     if not id:
         id = model.insert(content)
 
-    url = id_url(b85=id_b85(id))
+    url = id_url(b36='{:0>3}'.format(int_b36(int(id))))
     return redirect(url, "{}\n".format(url), 200)

--- a/util.py
+++ b/util.py
@@ -1,9 +1,8 @@
 from os import path
-from base64 import urlsafe_b64encode, urlsafe_b64decode, b85encode, b85decode
+import string
+from base64 import urlsafe_b64encode, urlsafe_b64decode
 from bitstring import Bits
 import binascii
-
-from urllib.parse import quote, unquote
 
 from flask import Response, render_template, current_app, request, url_for
 
@@ -51,13 +50,15 @@ def b64_id(b64):
     except binascii.Error:
         pass
 
-def id_b85(id):
-    b85 = b85encode(Bits(length=16, int=int(id)).bytes)
-    return quote(b85)
-
-def b85_id(b85):
-    b85 = unquote(b85)
-    return Bits(bytes=b85decode(b85)).int
+def int_b36(i):
+    char_set = string.digits + string.ascii_lowercase
+    if i < 36:
+        return char_set[i]
+    b36 = ''
+    while i != 0:
+        i, n = divmod(i, 36)
+        b36 = char_set[n] + b36
+    return b36
 
 def id_url(**kwargs):
     return url_for('.get', _external=True, _scheme='https', **kwargs)


### PR DESCRIPTION
We could/should eventually use a higher base (with url-safe characters), then replace the base64 stuff too. Doing do would mean abandoning the `int(s, 36)` fun-ness that we currently get.

also needs:

``` sql
DELETE FROM url;
```

for extra fun:

``` sql
ALTER TABLE url AUTO_INCREMENT = 2000;
```
