### PR TITLE
detect request scheme rather than guess https

### DIFF
--- a/util.py
+++ b/util.py
@@ -47,4 +47,6 @@ def b66_int(s):
     return sum(b66c.index(c) * len(b66c) ** (len(s) - i - 1) for i, c in enumerate(s))
 
 def id_url(**kwargs):
-    return url_for('.get', _external=True, _scheme='https', **kwargs)
+    proto = request.environ.get('HTTP_X_FORWARDED_PROTO')
+    scheme = proto if proto else request.scheme
+    return url_for('.get', _external=True, _scheme=scheme, **kwargs)


### PR DESCRIPTION
Because `_scheme='https'` is completely retarded.

Also needs (already present on leviathan):

``` nginx
proxy_set_header X-Forwarded-Proto https;
```

inside `location {}`.
