### PR TITLE
paste/model: create new short field, to support non-regex indexes of short IDs

### DIFF
--- a/pb/paste/model.py
+++ b/pb/paste/model.py
@@ -43,6 +43,7 @@ def _put(stream):
     return dict(
         content = b,
         digest = digest,
+        short = digest[-6:],
         size = size
     )
 

--- a/pb/paste/views.py
+++ b/pb/paste/views.py
@@ -163,16 +163,7 @@ def _get_paste(cb, sid=None, sha1=None, label=None, namespace=None):
     if sid:
         sid, name, value = sid
         return cb(**{
-            '$or' : [
-                {
-                    'digest': {
-                        '$regex': '{}$'.format(sid)
-                    }
-                },
-                {
-                    'label' : value
-                }
-            ],
+            'short': sid,
             'private': {
                 '$exists': False
             },

--- a/pb/runonce.py
+++ b/pb/runonce.py
@@ -27,6 +27,7 @@ def add_config_user(db):
 
 def add_indexes(db):
     db.pastes.create_index('digest', unique=True)
+    db.pastes.create_index('short', unique=True)
     db.pastes.create_index('date')
     db.pastes.create_index('label', unique=True, sparse=True)
     db.pastes.create_index(


### PR DESCRIPTION
This fixes performance issues with extremely slow index scans.

This also removes support for ultra-legacy pastes, further improving performance.