### PR TITLE
pb: delete-before-get paste expiry

### DIFF
--- a/pb/cache.py
+++ b/pb/cache.py
@@ -46,9 +46,10 @@ def get_session():
 
 def invalidate(**kwargs):
     cur = model.get_meta(**kwargs)
-    if not cur or not cur.count():
+    try:
+        paste = next(cur)
+    except StopIteration:
         return
-    paste = next(cur)
 
     base = current_app.config.get('VARNISH_BASE')
     if not base:

--- a/pb/pb.py
+++ b/pb/pb.py
@@ -21,7 +21,7 @@ from pb.logging import init_logging
 from pb.namespace.views import namespace
 from pb.paste.handler import HandlerConverter
 from pb.paste.views import paste
-from pb.responses import BaseResponse
+from pb.responses import BaseResponse, StatusResponse
 from pb.routing import RequestContext, Rule
 from pb.template import init_template
 
@@ -77,6 +77,9 @@ def create_app(config_filename='config.yaml'):
 
     app.register_blueprint(paste)
     app.register_blueprint(namespace)
+
+    # error handlers
+    app.register_error_handler(StopIteration, lambda _: StatusResponse("not found", 404))
 
     app.url_map.update()
     #print('\n'.join(repr(i) for i in app.url_map._rules))

--- a/tests/test_paste_sunset.py
+++ b/tests/test_paste_sunset.py
@@ -23,8 +23,30 @@ def test_paste_sunset():
     rv = app.test_client().get(url)
     data = load(rv.get_data())
 
-    assert data['status'] == 'expired'
+    assert data['status'] == 'not found'
 
     rv = app.test_client().get(url)
 
     assert rv.status_code == 404
+
+
+def test_paste_sunset_expire_before_get():
+    app = create_app()
+
+    c = str(time())
+
+    app.test_client().post('/', data=dict(
+        c=c,
+        s=1
+    ))
+
+    sleep(1)
+
+    rv = app.test_client().post('/', data=dict(
+        c=c,
+        s=1
+    ))
+
+    assert rv.status_code == 200
+    data = load(rv.get_data())
+    assert data['status'] == 'created'


### PR DESCRIPTION
This adds support for delete-before-get paste expiry behavior.

The previous behavior was, a paste would not be deleted until retrieved via GET,
as a consequence of the delete logic being implemented there.

The expiry implementation has been moved to the model, making expiry
calculations mandatory for all get types.

As a consequence of convenience, this necessarily refactors all count() method
calls into more-direct next/stopiteration blocks (most usages were only
concerned about >0 items, not the actual count), also adding a global error
handler for views that choose to bubble up this exception.